### PR TITLE
fix tv series search bar pushes content down

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,12 +61,17 @@ input#searchText {
   flex-direction: column;
   padding: 0;
   margin: 0;
+  position: absolute;
 }
 
 #search-dropdown-ul li {
   height: 2rem;
   padding: 0 0.5rem;
   margin: 0;
+  position: relative;
+  z-index: 1;
+  background-color: white;
+  width: 55%;
 }
 
 #search-dropdown-ul li:hover {


### PR DESCRIPTION
- How to reproduce the bug
1. Go to index page of application
2. Start searching for any tv series, for eg. "Money" 
3. The popular tv series section, gets pushed down abruptly by the suggestions

- Fix
1. To fix the bug, we increase the z-index of suggestions relative to search bar